### PR TITLE
Fix links

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,6 +63,10 @@
   const SETTINGSJS_VIEW_URL =
     "https://github.com/emscripten-core/emscripten/blob/main/src/settings.js";
 
+  function linkify(text) {
+    return text.replaceAll(/https?:\/\/.*?(?=[^\w/]*(?:\s|$))/g, `<a href="$&" target="_blank">$&</a>`);
+  }
+
   function parseBlock(block) {
     const firstLine = block[0].lineNumber;
     const lastLine = block.slice(-1)[0].lineNumber;
@@ -91,8 +95,7 @@
       comment: comment
         .slice(0, hasFlags ? -1 : comment.length)
         .map(line => line.replace(COMMENT, ""))
-        .join("\n")
-        .replaceAll(/https?:\/\/\S+/g, `<a href="$&" target="_blank">$&</a>`),
+        .join("\n"),
       flagName,
       defaultValue,
       isLinkTime,
@@ -175,8 +178,8 @@
               target="_blank"
               >(source)</a>
         </h1>
-        <div class="doc">${comment}</div>
-        <pre class="default">-s ${flagName} = ${defaultValue}</pre>
+        <div class="doc">${linkify(comment)}</div>
+        <pre class="default">-s ${flagName} = ${linkify(defaultValue)}</pre>
         ${
           hasFlags
             ? html`

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
 </footer>
 <script type="module">
   const html = String.raw;
-  const COMMENT = /\s*\/\/\s?/g;
+  const COMMENT = /\s*\/\/\s?/;
   const RAW_SETTINGSJS_URL =
     "https://raw.githubusercontent.com/emscripten-core/emscripten/main/src/settings.js";
   const SETTINGSJS_VIEW_URL =
@@ -90,8 +90,9 @@
     return {
       comment: comment
         .slice(0, hasFlags ? -1 : comment.length)
-        .map(line => line.replaceAll(COMMENT, ""))
-        .join("\n"),
+        .map(line => line.replace(COMMENT, ""))
+        .join("\n")
+        .replaceAll(/https?:\/\/\S+/g, `<a href="$&" target="_blank">$&</a>`),
       flagName,
       defaultValue,
       isLinkTime,


### PR DESCRIPTION
Previously, this was looking for and stripping `//` anywhere in the line, resulting in `//` stripped in URLs, e.g.:

![image](https://user-images.githubusercontent.com/557590/201706662-e0a4556e-400f-4215-9573-f91987bdbaef.png)


After this change, only first `//` - that is, the actual comment annotation - is stripped. Additionally, I've added auto-linkification of all URLs:

![image](https://user-images.githubusercontent.com/557590/201706622-c2963c6b-3b36-4e85-b3b3-20cf362d8f40.png)
